### PR TITLE
env variable to customize default columns

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -95,7 +95,7 @@ impl App {
         let available_states = JobState::get_available_states();
 
         // Default columns and sort options
-        let selected_columns = JobColumn::defaults();
+        let selected_columns = JobColumn::from_env_or_defaults();
         let sort_columns = vec![SortColumn {
             column: JobColumn::Id,
             order: SortOrder::Ascending,

--- a/src/ui/columns.rs
+++ b/src/ui/columns.rs
@@ -6,6 +6,8 @@ use ratatui::{
     widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph},
     Frame,
 };
+use std::env;
+
 
 /// Available columns for display in job list
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -144,6 +146,61 @@ impl JobColumn {
             JobColumn::QoS,
         ]
     }
+
+    // Parse a string to a column value
+    fn from_str(s: &str) -> Option<JobColumn> {
+        match s.to_lowercase().as_str() {
+            "id" => Some(JobColumn::Id),
+            "name" => Some(JobColumn::Name),
+            "user" => Some(JobColumn::User),
+            "state" => Some(JobColumn::State),
+            "partition" => Some(JobColumn::Partition),
+            "qos" => Some(JobColumn::QoS),
+            "nodes" => Some(JobColumn::Nodes),
+            "node" => Some(JobColumn::Node),
+            "cpus" => Some(JobColumn::CPUs),
+            "time" => Some(JobColumn::Time),
+            "memory" => Some(JobColumn::Memory),
+            "account" => Some(JobColumn::Account),
+            "priority" => Some(JobColumn::Priority),
+            "workdir" => Some(JobColumn::WorkDir),
+            "submittime" => Some(JobColumn::SubmitTime),
+            "starttime" => Some(JobColumn::StartTime),
+            "endtime" => Some(JobColumn::EndTime),
+            "preason" => Some(JobColumn::PReason),
+            _ => None,
+        }
+    }
+
+    // Load columns from ENV or use default
+    pub fn from_env_or_defaults() -> Vec<JobColumn> {
+        match env::var("SLURMER_COLUMNS") {
+            Ok(env_value) => {
+                let mut columns = Vec::new();
+                // ID is always default
+                columns.push(JobColumn::Id);
+
+                for name in env_value.split(","){
+                    let trimmed = name.trim();
+                    if let Some(column) = Self::from_str(trimmed){
+                        if column != Self::Id && !columns.contains(&column){
+                            columns.push(column);
+                        }
+                    }
+                }
+                
+
+                // If only ID, fallback to defaults
+                if columns.len() == 1 {
+                    Self::defaults()
+                } else {
+                    columns
+                }
+            }
+            Err(_) => Self::defaults()
+        }
+    }
+
 }
 
 /// Sort order for columns


### PR DESCRIPTION
I was thinking it would be cool to be able to permanently set up which columns to show by default, `squeue` does the same by using the `SQUEUE_FORMAT` env variable. I added a way to set the `SLURMER_COLUMNS` to do that.

For example : `export SLURMER_COLUMNS="name,account,user,time,cpus,priority"` would make those columns be the default.Let me know if you have any changes you would like to do to my implementation, I would be happy to do them.


Also, I have a couple of other ideas i would like to implement and i might as well ask here before i implement them.

1) I would like for a way to show all jobs and not only the default users, that could be another env variable (would start being a lot of env vars), or a command argument (`--no-user` or `--no-defaults`), i use that to be able to see traffic on the cluster and know when my jobs are going to run. 

2) Another feature I would like is a way to be able to filter by account (the `--account` flag on squeue), we use accounts in one of the clusters i work on for compute hour accounting and multiple users can be on the same account (project), so i would be useful for us. That would just add another box in the filters menu.

I would like to try and implement those if you are open for pull requests. 